### PR TITLE
Memory-efficient data processing

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -36,7 +36,7 @@ install_requires =
     numpy>=1.16.5
     pandas>=1.1.1
     rxn-chem-utils>=1.0.4
-    rxn-utils>=1.3.0
+    rxn-utils>=1.4.0
     tabulate>=0.8.7
     xxhash>=2.0.0
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -36,7 +36,7 @@ install_requires =
     numpy>=1.16.5
     pandas>=1.1.1
     rxn-chem-utils>=1.0.4
-    rxn-utils>=1.4.0
+    rxn-utils>=1.4.1
     tabulate>=0.8.7
     xxhash>=2.0.0
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -36,7 +36,7 @@ install_requires =
     numpy>=1.16.5
     pandas>=1.1.1
     rxn-chem-utils>=1.0.4
-    rxn-utils>=1.1.2
+    rxn-utils>=1.3.0
     tabulate>=0.8.7
     xxhash>=2.0.0
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -36,7 +36,7 @@ install_requires =
     numpy>=1.16.5
     pandas>=1.1.1
     rxn-chem-utils>=1.0.4
-    rxn-utils>=1.4.1
+    rxn-utils>=1.5.0
     tabulate>=0.8.7
     xxhash>=2.0.0
 

--- a/src/rxn/reaction_preprocessing/annotations/molecule_annotation.py
+++ b/src/rxn/reaction_preprocessing/annotations/molecule_annotation.py
@@ -49,7 +49,7 @@ class MoleculeAnnotation:
         """
 
         decision_enum = AnnotationDecision.from_string(decision)
-        self.__attrs_init__(  # type: ignore
+        self.__attrs_init__(
             original_smiles=original_smiles,
             updated_smiles=updated_smiles,
             decision=decision_enum,

--- a/src/rxn/reaction_preprocessing/augmenter.py
+++ b/src/rxn/reaction_preprocessing/augmenter.py
@@ -37,6 +37,11 @@ def molecules_permutation_given_index(
 
 
 class Augmenter:
+    """Augmenter.
+
+    Note: Unlike the other classes, which are memory-efficient, this one loads the
+    whole data in a pandas DataFrame for processing.
+    """
     def __init__(
         self, df: pd.DataFrame, reaction_column_name: str, fragment_bond: str = "."
     ):

--- a/src/rxn/reaction_preprocessing/augmenter.py
+++ b/src/rxn/reaction_preprocessing/augmenter.py
@@ -42,6 +42,7 @@ class Augmenter:
     Note: Unlike the other classes, which are memory-efficient, this one loads the
     whole data in a pandas DataFrame for processing.
     """
+
     def __init__(
         self, df: pd.DataFrame, reaction_column_name: str, fragment_bond: str = "."
     ):

--- a/src/rxn/reaction_preprocessing/config.py
+++ b/src/rxn/reaction_preprocessing/config.py
@@ -106,9 +106,8 @@ class RxnImportConfig:
         column_for_heat: name of the column containing boolean values that indicate
             whether the reaction happens under heat. If specified, the heat token will
             be added to the precursors of the corresponding reactions.
-        keep_intermediate_columns: Whether the columns generated during preprocessing should be kept.
-        keep_original_rxn_column: if  ``keep_intermediate_columns`` is False, determines whether
-            the original column with the raw reaction SMILES is to be kept or not.
+        keep_original_rxn_column: determines whether the original column with the
+            raw reaction SMILES is to be kept or not.
     """
 
     input_file: str = SI("${data.path}")
@@ -120,7 +119,6 @@ class RxnImportConfig:
     remove_atom_mapping: bool = True
     column_for_light: Optional[str] = None
     column_for_heat: Optional[str] = None
-    keep_intermediate_columns: bool = SI("${common.keep_intermediate_columns}")
     keep_original_rxn_column: bool = False
 
 

--- a/src/rxn/reaction_preprocessing/importer.py
+++ b/src/rxn/reaction_preprocessing/importer.py
@@ -1,12 +1,11 @@
 import logging
-from functools import partial
-from typing import Callable, Optional
+from typing import Callable, Optional, TextIO
 
-import pandas as pd
 from rxn.chemutils.reaction_equation import ReactionEquation
 from rxn.chemutils.reaction_smiles import parse_any_reaction_smiles
 from rxn.chemutils.utils import remove_atom_mapping
-from rxn.utilities.containers import remove_duplicates
+from rxn.utilities.csv import CsvIterator, StreamingCsvEditor
+from rxn.utilities.files import PathLike
 
 from rxn.reaction_preprocessing.config import InitialDataFormat, RxnImportConfig
 from rxn.reaction_preprocessing.special_tokens import add_heat_token, add_light_token
@@ -25,219 +24,247 @@ class RxnImportError(ValueError):
 class InvalidColumn(RxnImportError):
     """Exception when a required column does not exist."""
 
-    def __init__(self, column_name: str, file_name: str):
-        super().__init__(f'No column named "{column_name}" in the file "{file_name}".')
+    def __init__(self, column_name: str):
+        super().__init__(f'No column named "{column_name}" in the input file.')
 
 
-class InvalidType(RxnImportError):
-    """Exception when a column contains data of the incorrect type."""
+def _str2bool(v: str) -> bool:
+    return v.lower() in ("yes", "true", "t", "1")
 
-    def __init__(self, column_name: str, expected_type: str, actual_type: str):
-        super().__init__(
-            f'The column "{column_name}" is expected to contain '
-            f"values of type {expected_type} (actual: {actual_type})."
+
+class RxnImporter:
+    def __init__(
+        self,
+        data_format: InitialDataFormat,
+        input_csv_column_name: str,
+        reaction_column_name: str,
+        fragment_bond: str,
+        remove_atom_maps: bool,
+        column_for_light: Optional[str],
+        column_for_heat: Optional[str],
+    ):
+        self.data_format = data_format
+        self.input_csv_column_name = input_csv_column_name
+        self.reaction_column_name = reaction_column_name
+        self.fragment_bond = fragment_bond
+        self.remove_atom_maps = remove_atom_maps
+        self.column_for_light = column_for_light
+        self.column_for_heat = column_for_heat
+
+    def import_rxns(self, input_file: PathLike, output_csv: PathLike) -> None:
+        with open(input_file, "rt") as f_in, open(output_csv, "wt") as f_out:
+            csv_iterator = self._load_initial(f_in)
+
+            csv_iterator = self._parse_reaction_smiles(csv_iterator)
+
+            # Add special tokens when necessary
+            csv_iterator = self._maybe_add_light_token(csv_iterator)
+            csv_iterator = self._maybe_add_heat_token(csv_iterator)
+
+            csv_iterator = self._maybe_remove_atom_mapping(csv_iterator)
+            csv_iterator.to_stream(f_out)
+
+    def _load_initial(self, input_stream: TextIO) -> CsvIterator:
+        """
+        Load the initial dataframe.
+
+        This functions (and the ones it calls) make sure to rename the column
+        containing the data if it would be overwritten when transforming. The
+        column with the data ends up with the name `_final_column_name_for_original`.
+        """
+
+        if self.data_format is InitialDataFormat.TXT:
+            return self._load_from_txt(input_stream)
+        if self.data_format is InitialDataFormat.CSV:
+            return self._load_from_csv(input_stream, separator=",")
+        if self.data_format is InitialDataFormat.TSV:
+            return self._load_from_csv(input_stream, separator="\t")
+        raise ValueError(f"Unsupported data type: {self.data_format}")
+
+    def _load_from_txt(self, input_stream: TextIO) -> CsvIterator:
+        column_original = self._final_column_name_for_original()
+        return CsvIterator(
+            columns=[column_original],
+            rows=([line.rstrip("\r\n")] for line in input_stream),
         )
 
+    def _load_from_csv(self, input_stream: TextIO, separator: str) -> CsvIterator:
+        csv_iterator = CsvIterator.from_stream(input_stream, delimiter=separator)
 
-def _final_column_name_for_original(cfg: RxnImportConfig) -> str:
-    """Name of the column where the original data will end up."""
+        if self.input_csv_column_name not in csv_iterator.columns:
+            raise InvalidColumn(self.input_csv_column_name)
 
-    # For txt: always with "_original" postfix
-    if cfg.data_format is InitialDataFormat.TXT:
-        return f"{cfg.reaction_column_name}_original"
+        # if the name of the import column and of the output column collide: rename it.
+        if self.input_csv_column_name == self.reaction_column_name:
+            csv_iterator.columns = [
+                self._final_column_name_for_original()
+                if c == self.input_csv_column_name
+                else c
+                for c in csv_iterator.columns
+            ]
 
-    # For csv: only add "_original" postfix if the input and output columns are identical
-    if cfg.input_csv_column_name == cfg.reaction_column_name:
-        return f"{cfg.reaction_column_name}_original"
+        return csv_iterator
 
-    return cfg.input_csv_column_name
+    def _final_column_name_for_original(self) -> str:
+        """Name of the column where the original data will end up."""
 
+        # For txt: always with "_original" postfix
+        if self.data_format is InitialDataFormat.TXT:
+            return f"{self.reaction_column_name}_original"
 
-def _load_from_txt(cfg: RxnImportConfig) -> pd.DataFrame:
-    column_original = _final_column_name_for_original(cfg)
-    df: pd.DataFrame = pd.read_csv(cfg.input_file, names=[column_original])
-    return df
+        # For csv: only add "_original" postfix if the input and output columns are identical
+        if self.input_csv_column_name == self.reaction_column_name:
+            return f"{self.reaction_column_name}_original"
 
+        return self.input_csv_column_name
 
-def _load_from_csv(cfg: RxnImportConfig, separator: str) -> pd.DataFrame:
-    df: pd.DataFrame = pd.read_csv(cfg.input_file, sep=separator)
+    def _parse_reaction_smiles(self, csv_iterator: CsvIterator) -> CsvIterator:
+        editor = StreamingCsvEditor(
+            [self._final_column_name_for_original()],
+            [self.reaction_column_name],
+            self._reformat_smiles,
+        )
+        csv_iterator = editor.process(csv_iterator)
+        return self._remove_invalid(csv_iterator)
 
-    if cfg.input_csv_column_name not in df.columns:
-        raise InvalidColumn(cfg.input_csv_column_name, cfg.input_file)
+    def _reformat_smiles(self, reaction_smiles: str) -> str:
+        """Import a reaction SMILES in any format and convert it to an "IBM" RXN
+        SMILES with the specified fragment bond.
 
-    # if the name of the import column and of the output column collide: rename it.
-    if cfg.input_csv_column_name == cfg.reaction_column_name:
-        df.rename(
-            columns={cfg.input_csv_column_name: _final_column_name_for_original(cfg)},
-            inplace=True,
+        An empty string is returned if the reaction SMILES is not valid.
+        """
+
+        try:
+            reaction = parse_any_reaction_smiles(reaction_smiles)
+            return reaction.to_string(self.fragment_bond)
+        except Exception:
+            logger.info(f"Invalid reaction: {reaction_smiles}")
+            return ""
+
+    def _remove_invalid(self, csv_iterator: CsvIterator) -> CsvIterator:
+        rxn_idx = csv_iterator.column_index(self.reaction_column_name)
+
+        # Filter out the ones that have an empty SMILES string (note: is empty
+        # if the import was unsuccessful).
+        return CsvIterator(
+            csv_iterator.columns, (row for row in csv_iterator.rows if row[rxn_idx])
         )
 
-    return df
+    def _maybe_add_special_token(
+        self,
+        csv_iterator: CsvIterator,
+        add_special_token_fn: Callable[[ReactionEquation], ReactionEquation],
+        special_token_column: Optional[str],
+    ) -> CsvIterator:
+        """
+        Common function for adding light or heat tokens.
 
+        Args:
+            csv_iterator: iterator where to update the reaction SMILES.
+            add_special_token_fn: function to call on a ReactionEquation to add the required token.
+            special_token_column: column to look at in order to know when to add the special tokens.
+        """
 
-def _load_initial(cfg: RxnImportConfig) -> pd.DataFrame:
-    """
-    Load the initial dataframe.
+        # Do nothing if no column was specified for the special token
+        if special_token_column is None:
+            return csv_iterator
 
-    This functions (and the ones it calls) make sure to rename the column
-    containing the data if it would be overwritten when transforming. The
-    column with the data ends up with the name `_final_column_name_for_original`.
-    """
+        if special_token_column not in csv_iterator.columns:
+            raise InvalidColumn(special_token_column)
 
-    if cfg.data_format is InitialDataFormat.TXT:
-        return _load_from_txt(cfg)
-    if cfg.data_format is InitialDataFormat.CSV:
-        return _load_from_csv(cfg, separator=",")
-    if cfg.data_format is InitialDataFormat.TSV:
-        return _load_from_csv(cfg, separator="\t")
-    raise ValueError(f"Unsupported data type: {cfg.data_format}")
+        # "partial" in order to make the function compatible with pandas.apply().
+        def fn(reaction_smiles: str, special_token: str) -> str:
+            return self._add_token(reaction_smiles, special_token, add_special_token_fn)
 
+        editor = StreamingCsvEditor(
+            [self.reaction_column_name, special_token_column],
+            [self.reaction_column_name],
+            fn,
+        )
+        return editor.process(csv_iterator)
 
-def reformat_smiles(
-    reaction_smiles: str, fragment_bond: Optional[str]
-) -> Optional[str]:
-    """Import a reaction SMILES in any format and convert it to an "IBM" RXN
-    SMILES with the specified fragment bond.
+    def _maybe_add_heat_token(self, csv_iterator: CsvIterator) -> CsvIterator:
+        """Add the heat token to the precursors of the reaction SMILES when necessary."""
 
-    `None` is returned if the reaction SMILES is not valid.
-    """
+        return self._maybe_add_special_token(
+            csv_iterator,
+            add_special_token_fn=add_heat_token,
+            special_token_column=self.column_for_heat,
+        )
 
-    try:
+    def _maybe_add_light_token(self, csv_iterator: CsvIterator) -> CsvIterator:
+        """Add the light token to the precursors of the reaction SMILES when necessary."""
+
+        return self._maybe_add_special_token(
+            csv_iterator,
+            add_special_token_fn=add_light_token,
+            special_token_column=self.column_for_light,
+        )
+
+    def _maybe_remove_atom_mapping(self, csv_iterator: CsvIterator) -> CsvIterator:
+        """Remove the atom mapping if required by the config.
+
+        NB: This will not clean up the SMILES, i.e. "[CH3:1][CH3:2]" is converted
+        to "[CH3][CH3]" and not to "CC". The standardization step will do that.
+        """
+
+        if not self.remove_atom_maps:
+            return csv_iterator
+
+        editor = StreamingCsvEditor(
+            [self.reaction_column_name],
+            [self.reaction_column_name],
+            remove_atom_mapping,
+        )
+        return editor.process(csv_iterator)
+
+    def _add_token(
+        self,
+        reaction_smiles: str,
+        special_token: str,
+        add_special_token_fn: Callable[[ReactionEquation], ReactionEquation],
+    ) -> str:
+        """Function to use with StreamingCsvEditor to update the reaction SMILES."""
+
+        special_flag_active = _str2bool(special_token)
+
+        if not special_flag_active:
+            # do nothing if the reaction is not run under light / heat / etc.
+            return reaction_smiles
+
         reaction = parse_any_reaction_smiles(reaction_smiles)
-        return reaction.to_string(fragment_bond)
-    except Exception:
-        logger.info(f"Invalid reaction: {reaction_smiles}")
-        return None
+        reaction = add_special_token_fn(reaction)
 
-
-def _add_token(
-    row: pd.Series,
-    add_special_token_fn: Callable[[ReactionEquation], ReactionEquation],
-    column_to_check: str,
-    cfg: RxnImportConfig,
-) -> str:
-    """Function to use in pandas.apply to update the reaction SMILES."""
-
-    reaction_smiles: str = row[cfg.reaction_column_name]
-    special_flag_active = row[column_to_check]
-
-    if not isinstance(special_flag_active, bool):
-        raise InvalidType(
-            column_name=column_to_check,
-            expected_type="bool",
-            actual_type=str(type(special_flag_active).__name__),
-        )
-
-    if not special_flag_active:
-        # do nothing if the reaction is not run under light / heat / etc.
-        return reaction_smiles
-
-    reaction = parse_any_reaction_smiles(reaction_smiles)
-    reaction = add_special_token_fn(reaction)
-
-    return reaction.to_string(cfg.fragment_bond.value)
-
-
-def _maybe_add_special_token(
-    df: pd.DataFrame,
-    cfg: RxnImportConfig,
-    add_special_token_fn: Callable[[ReactionEquation], ReactionEquation],
-    special_token_column: Optional[str],
-) -> None:
-    """
-    Common function for adding light or heat tokens.
-
-    Args:
-        df: DataFrame where to update the reaction SMILES.
-        cfg: config.
-        add_special_token_fn: function to call on a ReactionEquation to add the required token.
-        special_token_column: column to look at in order to know when to add the special tokens.
-    """
-
-    # Do nothing if no column was specified for the special token
-    if special_token_column is None:
-        return
-
-    if special_token_column not in df.columns:
-        raise InvalidColumn(special_token_column, cfg.input_file)
-
-    # "partial" in order to make the function compatible with pandas.apply().
-    fn = partial(
-        _add_token,
-        add_special_token_fn=add_special_token_fn,
-        column_to_check=special_token_column,
-        cfg=cfg,
-    )
-    df[cfg.reaction_column_name] = df.apply(fn, axis=1)
-
-
-def _maybe_add_heat_token(df: pd.DataFrame, cfg: RxnImportConfig) -> None:
-    """Add the heat token to the precursors of the reaction SMILES when necessary."""
-
-    _maybe_add_special_token(
-        df=df,
-        cfg=cfg,
-        add_special_token_fn=add_heat_token,
-        special_token_column=cfg.column_for_heat,
-    )
-
-
-def _maybe_add_light_token(df: pd.DataFrame, cfg: RxnImportConfig) -> None:
-    """Add the light token to the precursors of the reaction SMILES when necessary."""
-
-    _maybe_add_special_token(
-        df=df,
-        cfg=cfg,
-        add_special_token_fn=add_light_token,
-        special_token_column=cfg.column_for_light,
-    )
-
-
-def _maybe_remove_atom_mapping(df: pd.DataFrame, cfg: RxnImportConfig) -> None:
-    """Remove the atom mapping if required by the config.
-
-    NB: This will not clean up the SMILES, i.e. "[CH3:1][CH3:2]" is converted
-    to "[CH3][CH3]" and not to "CC". The standardization step will do that.
-    """
-
-    if not cfg.remove_atom_mapping:
-        return
-
-    df[cfg.reaction_column_name] = df[cfg.reaction_column_name].apply(
-        remove_atom_mapping
-    )
+        return reaction.to_string(self.fragment_bond)
 
 
 def rxn_import(cfg: RxnImportConfig) -> None:
     """
     Initial import of reaction data, as a first step of the reaction preprocessing.
     """
+    # TODO:
+    # keep_intermediate_columns: bool = SI("${common.keep_intermediate_columns}")
+    # keep_original_rxn_column: bool = False
 
-    df = _load_initial(cfg)
+    importer = RxnImporter(
+        data_format=cfg.data_format,
+        input_csv_column_name=cfg.input_csv_column_name,
+        reaction_column_name=cfg.reaction_column_name,
+        fragment_bond=cfg.fragment_bond.value,
+        remove_atom_maps=cfg.remove_atom_mapping,
+        column_for_light=cfg.column_for_light,
+        column_for_heat=cfg.column_for_heat,
+    )
 
-    # Define which columns are to keep when cfg.keep_intermediate_columns is False:
-    # The ones in the input file, except the one that is converted to the final rxn column
-    raw_rxn_column = [cfg.input_csv_column_name, f"{cfg.reaction_column_name}_original"]
-    if cfg.keep_original_rxn_column:
-        raw_rxn_column = []
-    columns_to_keep = [c for c in df.columns if c not in raw_rxn_column]
-    columns_to_keep = remove_duplicates(columns_to_keep + [cfg.reaction_column_name])
+    # # Define which columns are to keep when cfg.keep_intermediate_columns is False:
+    # # The ones in the input file, except the one that is converted to the final rxn column
+    # raw_rxn_column = [cfg.input_csv_column_name, f"{cfg.reaction_column_name}_original"]
+    # if cfg.keep_original_rxn_column:
+    #     raw_rxn_column = []
+    # columns_to_keep = [c for c in df.columns if c not in raw_rxn_column]
+    # columns_to_keep = remove_duplicates(columns_to_keep + [cfg.reaction_column_name])
+    #
+    # if not cfg.keep_intermediate_columns:
+    #     df = df[columns_to_keep]
 
-    # Reformat the reaction SMILES
-    fn = partial(reformat_smiles, fragment_bond=cfg.fragment_bond.value)
-    df[cfg.reaction_column_name] = df[_final_column_name_for_original(cfg)].apply(fn)
-
-    # Discard lines containing None (for unsuccessful reaction SMILES import)
-    df = df.dropna()
-
-    # Add special tokens when necessary
-    _maybe_add_light_token(df, cfg)
-    _maybe_add_heat_token(df, cfg)
-
-    # Remove atom mapping if necessary
-    _maybe_remove_atom_mapping(df, cfg)
-
-    if not cfg.keep_intermediate_columns:
-        df = df[columns_to_keep]
-
-    df.to_csv(cfg.output_csv, index=False)
+    importer.import_rxns(input_file=cfg.input_file, output_csv=cfg.output_csv)

--- a/src/rxn/reaction_preprocessing/preprocessor.py
+++ b/src/rxn/reaction_preprocessing/preprocessor.py
@@ -83,11 +83,17 @@ class Preprocessor:
         )
 
     def standardize_rxn_smiles(self, rxn_smiles: str) -> str:
-        """Function standardizing the reaction SMILES directly,
-        to pass to pandas.apply()."""
-        reaction = parse_any_reaction_smiles(rxn_smiles)
-        reaction = self.reaction_standardizer(reaction)
-        return reaction.to_string(self.fragment_bond)
+        """Standardizing the reaction SMILES.
+
+        If there is an error, returns ">>" instead.
+        """
+        try:
+            reaction = parse_any_reaction_smiles(rxn_smiles)
+            reaction = self.reaction_standardizer(reaction)
+            return reaction.to_string(self.fragment_bond)
+        except Exception as e:
+            logger.error(f'Cannot standardize reaction SMILES "{rxn_smiles}": {e}')
+            return ">>"
 
     def validate(
         self,

--- a/src/rxn/reaction_preprocessing/preprocessor.py
+++ b/src/rxn/reaction_preprocessing/preprocessor.py
@@ -6,15 +6,13 @@
 import collections
 import logging
 from pathlib import Path
-from typing import Callable, List, Optional, Counter, Tuple, Iterator
+from typing import Counter, Iterator, List, Tuple
 
-import numpy as np
-import pandas as pd
-from rdkit import RDLogger
 from rxn.chemutils.reaction_equation import ReactionEquation
 from rxn.chemutils.reaction_smiles import parse_any_reaction_smiles
 from rxn.utilities.containers import iterate_unique_values
 from rxn.utilities.csv import CsvIterator, StreamingCsvEditor
+from rxn.utilities.files import PathLike
 from tabulate import tabulate
 
 from .config import PreprocessConfig
@@ -28,278 +26,110 @@ logger.addHandler(logging.NullHandler())
 class Preprocessor:
     def __init__(
         self,
+        mixed_reaction_filter: MixedReactionFilter,
         reaction_column_name: str,
-        valid_column: str = "_rxn_valid",
-        valid_message_column: str = "_rxn_valid_messages",
         fragment_bond: str = ".",
-        clean_data: bool = True,
     ):
-        """Creates a new instance of the Preprocessor class.
-
+        """
         Args:
+            mixed_reaction_filter: mixed reaction filter.
             reaction_column_name: The name of the DataFrame column containing the reaction SMARTS.
-            valid_column: The name of the column to write the validation results to
-                (will be created if it doesn't exist). Defaults to "_rxn_valid".
-            valid_message_column: The name of the column to write the validation
-                messages to in verbose mode (will be created if it doesn't
-                exist). Defaults to "_rxn_valid_messages".
             fragment_bond: The token that represents fragment bonds in the reaction SMILES.
-            clean_data: Whether to run a simple pre-cleaning of the input data
-                (naive check for valid SMARTS reactions based on the number of
-                greater-thans in the string). Defaults to True.
         """
         self.reaction_standardizer = ReactionStandardizer()
-        self.__reaction_column_name = reaction_column_name
-        self.__valid_column = valid_column
-        self.__valid_message_column = valid_message_column
-        self.__fragment_bond = fragment_bond
+        self.mixed_reaction_filter = mixed_reaction_filter
+        self.rxn_column = reaction_column_name
+        self.fragment_bond = fragment_bond
 
-    def __filter_func(
-        self,
-        reaction_smiles: str,
-        filter: MixedReactionFilter,
-    ) -> bool:
-        """The default filter function.
+    def process(self, input_file_path: PathLike, output_file_path: PathLike) -> None:
+        with open(input_file_path, "rt") as f_in, open(output_file_path, "wt") as f_out:
+            csv_iterator = CsvIterator.from_stream(f_in)
 
-        Args:
-            reaction_smiles: An input reaction SMILES.
-            filter: An instance of MixedReactionFilter to test the reaction against.
+            # first deduplication
+            csv_iterator = self.remove_duplicate_reactions(csv_iterator)
 
-        Returns:
-            A boolean indicating whether or not the reaction is valid according
-            to the supplied parameters.
-        """
+            # reaction standardization
+            rxn_standardization_editor = StreamingCsvEditor(
+                [self.rxn_column], [self.rxn_column], self.standardize_rxn_smiles
+            )
+            csv_iterator = rxn_standardization_editor.process(csv_iterator)
 
-        reaction = ReactionEquation.from_string(
-            reaction_smiles, fragment_bond=self.__fragment_bond
+            # second deduplication
+            csv_iterator = self.remove_duplicate_reactions(csv_iterator)
+
+            # filtering
+            csv_iterator, error_counter = self.validate(
+                csv_iterator=csv_iterator,
+            )
+
+            csv_iterator.to_stream(f_out)
+
+            self.print_stats(
+                error_counter=error_counter,
+                original_count=-1,
+                valid_count=-1,
+                invalid_count=-1,
+            )
+
+    def remove_duplicate_reactions(self, csv_iterator: CsvIterator) -> CsvIterator:
+        rxn_idx = csv_iterator.column_index(self.rxn_column)
+
+        # The key for determining what is a duplicate is the value from the rxn column
+        def key(row: List[str]) -> str:
+            return row[rxn_idx]
+
+        return CsvIterator(
+            csv_iterator.columns, iterate_unique_values(csv_iterator.rows, key=key)
         )
-        return filter.is_valid(reaction)
-
-    def __filter_func_verbose(
-        self,
-        reaction_smiles: str,
-        filter: MixedReactionFilter,
-    ) -> List[str]:
-        """The default verbose filter function.
-
-        Args:
-            reaction_smiles: An input reaction SMILES.
-            filter: An instance of MixedReactionFilter to test the reaction against.
-
-        Returns:
-            A list of reasons for an invalid reaction. An empty list for a valid reaction.
-        """
-        invalid_reasons = []
-
-        reaction = ReactionEquation.from_string(
-            reaction_smiles, fragment_bond=self.__fragment_bond
-        )
-        _, filter_reasons = filter.validate_reasons(reaction)
-        invalid_reasons.extend(filter_reasons)
-
-        return invalid_reasons
-
-    #
-    # Public Methods
-    #
-    def filter(
-        self,
-        filter: MixedReactionFilter,
-        verbose: bool = False,
-        filter_func: Optional[Callable[[str, MixedReactionFilter], bool]] = None,
-        filter_func_verbose: Optional[
-            Callable[[str, MixedReactionFilter], List[str]]
-        ] = None,
-    ) -> "Preprocessor":
-        """Applies filter functions to the reaction. Alternatives for the default filter functions
-        can be supplied. The default filters remove reactions containing molecules that could not
-        be parse by rdkit's MolFromSmiles.
-
-        Args:
-            filter: An instance of MixedReactionFilter to be applied to each reaction.
-            verbose: Whether or not to report the reasons for a reaction being
-                deemed invalid. Defaults to False.
-            filter_func: A custom filter function. Defaults to None.
-            filter_func_verbose: A custom verbose filter function. Defaults to None.
-
-        Returns:
-            Itself.
-        """
-        if filter_func is None:
-            filter_func = self.__filter_func
-
-        if filter_func_verbose is None:
-            filter_func_verbose = self.__filter_func_verbose
-
-        if self.__valid_column not in self.df.columns:
-            self.df[self.__valid_column] = True
-
-        if verbose:
-            if self.__valid_message_column not in self.df.columns:
-                self.df[self.__valid_message_column] = np.empty(
-                    (len(self.df), 0)
-                ).tolist()
-
-            self.df[self.__valid_message_column] += self.df.apply(
-                lambda row: filter_func_verbose(
-                    row[self.__reaction_column_name], filter
-                ),
-                axis=1,
-            )
-
-            self.df[self.__valid_column] = np.logical_and(
-                np.where(self.df[self.__valid_message_column], False, True),
-                self.df[self.__valid_column],
-            )
-        else:
-            self.df[self.__valid_column] = np.logical_and(
-                self.df.apply(
-                    lambda row: filter_func(row[self.__reaction_column_name], filter),
-                    axis=1,
-                ),
-                self.df[self.__valid_column],
-            )
-
-        return self
 
     def standardize_rxn_smiles(self, rxn_smiles: str) -> str:
         """Function standardizing the reaction SMILES directly,
         to pass to pandas.apply()."""
         reaction = parse_any_reaction_smiles(rxn_smiles)
         reaction = self.reaction_standardizer(reaction)
-        return reaction.to_string(self.__fragment_bond)
+        return reaction.to_string(self.fragment_bond)
 
-    def reaction_standardization(self) -> None:
-        """
-        Reaction standardization, including merging of reactants and reactants,
-        removal of duplicates, sorting, etc.
+    def validate(
+        self,
+        csv_iterator: CsvIterator,
+    ) -> Tuple[CsvIterator, Counter[str]]:
+        rxn_idx = csv_iterator.column_index(self.rxn_column)
+        error_counter: Counter[str] = collections.Counter()
 
-        Note that this standardization relies on the molecules in the reaction
-        SMILES to be canonical - which is the case when this function is
-        called as part of the full data processing pipeline.
-        """
-
-        def standardize_smiles(rxn_smiles: str) -> str:
-            """Function standardizing the reaction SMILES directly,
-            to pass to pandas.apply()."""
-            reaction = parse_any_reaction_smiles(rxn_smiles)
-            reaction = self.reaction_standardizer(reaction)
-            return reaction.to_string(self.__fragment_bond)
-
-        rxn_column = self.__reaction_column_name
-        self.df[rxn_column] = self.df[rxn_column].apply(standardize_smiles)
-
-    def remove_duplicates(self) -> "Preprocessor":
-        """A wrapper around pandas' drop_duplicates with the argument subset
-        set to the reaction column name.
-
-        Returns:
-            Itself.
-        """
-        self.df.drop_duplicates(subset=[self.__reaction_column_name], inplace=True)
-        return self
-
-    def remove_invalids(self) -> "Preprocessor":
-        """A wrapper around removing invalid options from pandas DataFrame.
-
-        Returns:
-            Itself.
-        """
-        self.df.drop(
-            self.df[self.df[self.__valid_column] == False].index,  # noqa: E712
-            inplace=True,
-        )
-        return self
-
-    def print_stats(self) -> "Preprocessor":
-        """Prints statistics of the filtration to stdout.
-
-        Returns:
-            Itself.
-        """
-        logger.info(f"- {len(self.df)} total reactions.")
-        if self.__valid_column in self.df.columns:
-            counts = self.df[self.__valid_column].value_counts()
-            if True in counts:
-                logger.info(f"- {counts[True]} valid reactions.")
-            if False in counts:
-                logger.info(f"- {counts[False]} invalid reactions removed.")
-
-        if self.__valid_message_column in self.df.columns:
-            reasons: Counter[str] = collections.Counter()
-            for _, value in self.df[self.__valid_message_column].items():
-                reasons.update(value)
-
-            if len(reasons) > 0:
-                headers = ["Reason", "Number of Reactions"]
-                logger.info(
-                    f"- The {counts[False]} reactions were removed for the following reasons:\n"
-                    f'{tabulate(list(collections.Counter(reasons).items()), headers, tablefmt="fancy_grid")}'
+        def internal() -> Iterator[List[str]]:
+            for row in csv_iterator.rows:
+                reaction = ReactionEquation.from_string(
+                    row[rxn_idx], fragment_bond=self.fragment_bond
                 )
+                valid, reasons = self.mixed_reaction_filter.validate_reasons(reaction)
+                if valid:
+                    yield row
+                else:
+                    for reason in reasons:
+                        error_counter[reason] += 1
 
-        return self
+        return CsvIterator(columns=csv_iterator.columns, rows=internal()), error_counter
 
-    #
-    # Static Methods
-    #
-    @staticmethod
-    def read_csv(
-        filepath: str, reaction_column_name: str, fragment_bond: str = "."
-    ) -> "Preprocessor":
-        """A helper function to read a list or csv of reactions.
+    def print_stats(
+        self,
+        error_counter: Counter[str],
+        original_count: int,
+        valid_count: int,
+        invalid_count: int,
+    ) -> None:
+        """Prints statistics of the filtration to the logger."""
+        logger.info(f"- {original_count} total reactions.")
+        logger.info(f"- {valid_count} valid reactions.")
+        logger.info(f"- {invalid_count} invalid reactions removed.")
 
-        Args:
-            filepath: The path to the text file containing the reactions.
-            reaction_column_name: The name of the reaction column (or the name that
-                wil be given to the reaction column if the input file has no headers).
-            fragment_bond: The token that represents fragment bonds in the raction SMILES.
+        if sum(error_counter.values()) == 0:
+            return
 
-        Returns:
-            Preprocessor: A new preprocessor instance.
-        """
-        df = pd.read_csv(filepath, lineterminator="\n")
-        if len(df.columns) == 1:
-            df.rename(columns={df.columns[0]: reaction_column_name}, inplace=True)
-
-        return Preprocessor(df, reaction_column_name, fragment_bond=fragment_bond)
-
-
-def remove_duplicate_reactions(
-    csv_iterator: CsvIterator, rxn_column: str
-) -> CsvIterator:
-    rxn_idx = csv_iterator.column_index(rxn_column)
-
-    # The key for determining what is a duplicate is the value from the rxn column
-    def key(row: List[str]) -> str:
-        return row[rxn_idx]
-
-    return CsvIterator(
-        csv_iterator.columns, iterate_unique_values(csv_iterator.rows, key=key)
-    )
-
-
-def validate(
-    csv_iterator: CsvIterator,
-    rxn_column: str,
-    mfp: MixedReactionFilter,
-    fragment_bond: str,
-) -> Tuple[CsvIterator, Counter[str]]:
-    rxn_idx = csv_iterator.column_index(rxn_column)
-    error_counter = collections.Counter()
-
-    def internal() -> Iterator[List[str]]:
-        for row in csv_iterator.rows:
-            reaction = ReactionEquation.from_string(
-                row[rxn_idx], fragment_bond=fragment_bond
-            )
-            valid, reasons = mfp.validate_reasons(reaction)
-            if valid:
-                yield row
-            else:
-                for reason in reasons:
-                    error_counter[reason] += 1
-
-    return CsvIterator(columns=csv_iterator.columns, rows=internal()), error_counter
+        headers = ["Reason", "Number of Reactions"]
+        logger.info(
+            f"- The {invalid_count} reactions were removed for the following reasons:\n"
+            f'{tabulate(list(error_counter.items()), headers, tablefmt="fancy_grid")}'
+        )
 
 
 def preprocess(cfg: PreprocessConfig) -> None:
@@ -327,92 +157,9 @@ def preprocess(cfg: PreprocessConfig) -> None:
 
     rxn_column = cfg.reaction_column_name
     preprocessor = Preprocessor(
-        reaction_column_name=rxn_column, fragment_bond=cfg.fragment_bond.value
-    )  # other args TODO
-
-    with open(input_file_path, "rt") as f_in, open(output_file_path, "wt") as f_out:
-        csv_iterator = CsvIterator.from_stream(f_in)
-
-        # first deduplication
-        csv_iterator = remove_duplicate_reactions(csv_iterator, rxn_column)
-
-        # reaction standardization
-        rxn_standardization_editor = StreamingCsvEditor(
-            [rxn_column], [rxn_column], preprocessor.standardize_rxn_smiles
-        )
-        csv_iterator = rxn_standardization_editor.process(csv_iterator)
-
-        # second deduplication
-        csv_iterator = remove_duplicate_reactions(csv_iterator, rxn_column)
-
-        # filtering
-        csv_iterator, error_counter = validate(
-            csv_iterator=csv_iterator,
-            rxn_column=rxn_column,
-            mfp=mrf,
-            fragment_bond=cfg.fragment_bond.value,
-        )
-
-        csv_iterator.to_stream(f_out)
-
-        print(error_counter)
-
-
-def old_preprocess(cfg: PreprocessConfig) -> None:
-    RDLogger.DisableLog("rdApp.*")
-
-    output_file_path = Path(cfg.output_file_path)
-    if not Path(cfg.input_file_path).exists():
-        raise ValueError(
-            f"Input file for preprocessing does not exist: {cfg.input_file_path}"
-        )
-
-    # Create a instance of the mixed reaction filter with default values.
-    # Make arguments for all properties in script
-    mrf = MixedReactionFilter(
-        max_reactants=cfg.max_reactants,
-        max_agents=cfg.max_agents,
-        max_products=cfg.max_products,
-        min_reactants=cfg.min_reactants,
-        min_agents=cfg.min_agents,
-        min_products=cfg.min_products,
-        max_reactants_tokens=cfg.max_reactants_tokens,
-        max_agents_tokens=cfg.max_agents_tokens,
-        max_products_tokens=cfg.max_products_tokens,
-        max_absolute_formal_charge=cfg.max_absolute_formal_charge,
-    )
-
-    pp = Preprocessor.read_csv(
-        cfg.input_file_path,
-        cfg.reaction_column_name,
+        mixed_reaction_filter=mrf,
+        reaction_column_name=rxn_column,
         fragment_bond=cfg.fragment_bond.value,
     )
-    columns_to_keep = list(pp.df.columns)
 
-    # Remove duplicate reactions (useful for large dataset, this step is repeated later)
-    logger.info(f"- {len(pp.df)} initial reactions.")
-    pp.remove_duplicates()
-    logger.info(f"- {len(pp.df)} reactions after first deduplication.")
-
-    # Remove duplicate molecules, sort, etc.
-    # NB: this relies on molecules in the reaction SMILES to be canonical already!
-    pp.reaction_standardization()
-
-    # Remove duplicate reactions
-    pp.remove_duplicates()
-    logger.info(f"- {len(pp.df)} reactions after second deduplication.")
-
-    # Apply the mixed reaction filter instance defined above, enable verbose mode
-    pp.filter(mrf, True)
-
-    # Print the detailed stats
-    pp.print_stats()
-
-    # Drop the invalid reactions
-    pp.remove_invalids()
-
-    if not cfg.keep_intermediate_columns:
-        pp.df = pp.df[columns_to_keep]
-
-    # After dropping invalid columns, display stats again (as an example)
-    pp.df.to_csv(output_file_path, index=False)
+    preprocessor.process(input_file_path, output_file_path)

--- a/src/rxn/reaction_preprocessing/scripts/find_missing_annotations.py
+++ b/src/rxn/reaction_preprocessing/scripts/find_missing_annotations.py
@@ -1,5 +1,5 @@
 import click
-from rxn.utilities.files import iterate_csv_column
+from rxn.utilities.csv import iterate_csv_column
 
 from rxn.reaction_preprocessing.annotations.molecule_annotation import (
     load_annotations_multiple,

--- a/src/rxn/reaction_preprocessing/scripts/find_missing_annotations.py
+++ b/src/rxn/reaction_preprocessing/scripts/find_missing_annotations.py
@@ -1,6 +1,5 @@
-from typing import Optional
-
 import click
+from rxn.utilities.files import iterate_csv_column
 
 from rxn.reaction_preprocessing.annotations.molecule_annotation import (
     load_annotations_multiple,
@@ -12,16 +11,10 @@ from rxn.reaction_preprocessing.standardizer import Standardizer
 @click.command()
 @click.option("--csv_file", required=True)
 @click.option(
-    "--output_csv",
-    help="(optional) Where to save the CSV augmented with column for missing annotations.",
-)
-@click.option(
     "--column_name", required=True, help="Column containing the reaction SMILES"
 )
 @click.option("--fragment_bond", default="~")
-def main(
-    csv_file: str, output_csv: Optional[str], column_name: str, fragment_bond: str
-) -> None:
+def main(csv_file: str, column_name: str, fragment_bond: str) -> None:
     """Find the missing annotation in a set of reactions.
 
     The missing annotations will be printed to standard output, and optionally
@@ -33,8 +26,7 @@ def main(
 
     # To find the missing annotations, we mis-use the standardizer, which anyway
     # looks for the missing annotations if `discard_unannotated_metals` is True.
-    standardizer = Standardizer.read_csv(
-        csv_file,
+    standardizer = Standardizer(
         annotations=annotations,
         discard_unannotated_metals=True,
         reaction_column_name=column_name,
@@ -42,18 +34,11 @@ def main(
         remove_stereo_if_not_defined_in_precursors=False,
     )
 
-    standardizer.standardize()
-
-    # Save csv if required
-    if output_csv is not None:
-        standardizer.df.to_csv(output_csv, index=False)
-
     missing_annotations = set()
-    for missing_annotation_list in standardizer.df[
-        standardizer.missing_annotations_column
-    ]:
-        for missing_annotation in missing_annotation_list:
-            missing_annotations.add(missing_annotation)
+    input_reactions = iterate_csv_column(csv_file, column_name)
+    for rxn_smiles in input_reactions:
+        result = standardizer.standardize_one(rxn_smiles)
+        missing_annotations.update(result.missing_annotations)
 
     for missing_annotation in sorted(missing_annotations):
         print(missing_annotation)

--- a/src/rxn/reaction_preprocessing/stable_data_splitter.py
+++ b/src/rxn/reaction_preprocessing/stable_data_splitter.py
@@ -6,10 +6,11 @@
 import csv
 import functools
 from pathlib import Path
-from typing import Callable, Hashable, Iterable, List, Protocol
+from typing import Callable, Hashable, Iterable, List
 
 from rxn.utilities.csv import CsvIterator
 from rxn.utilities.files import PathLike, stable_shuffle
+from typing_extensions import Protocol
 from xxhash import xxh64_intdigest
 
 from rxn.reaction_preprocessing.config import SplitConfig

--- a/src/rxn/reaction_preprocessing/stable_data_splitter.py
+++ b/src/rxn/reaction_preprocessing/stable_data_splitter.py
@@ -183,11 +183,10 @@ def split(cfg: SplitConfig) -> None:
 
     # Get the file name without the extension
     stem = Path(cfg.input_file_path).stem
-    train_csv = output_directory / (stem + ".train.csv")
 
     splitter.split_file(
         input_csv=cfg.input_file_path,
-        train_csv=train_csv,
+        train_csv=output_directory / (stem + ".train.csv"),
         valid_csv=output_directory / (stem + ".validation.csv"),
         test_csv=output_directory / (stem + ".test.csv"),
     )

--- a/src/rxn/reaction_preprocessing/standardizer.py
+++ b/src/rxn/reaction_preprocessing/standardizer.py
@@ -148,12 +148,6 @@ class Standardizer:
         if self.keep_intermediate_columns:
             return LightCsvEditor(
                 columns_in=[self.rxn_column],
-                columns_out=[self.rxn_column],
-                transformation=self.inner_standardizer.standardize_small,
-            )
-        else:
-            return LightCsvEditor(
-                columns_in=[self.rxn_column],
                 columns_out=[
                     self.rxn_column,
                     self.rxn_before_std_column,
@@ -162,6 +156,12 @@ class Standardizer:
                     self.missing_annotations_column,
                 ],
                 transformation=self.inner_standardizer.standardize_big,
+            )
+        else:
+            return LightCsvEditor(
+                columns_in=[self.rxn_column],
+                columns_out=[self.rxn_column],
+                transformation=self.inner_standardizer.standardize_small,
             )
 
 

--- a/src/rxn/reaction_preprocessing/standardizer.py
+++ b/src/rxn/reaction_preprocessing/standardizer.py
@@ -3,7 +3,6 @@
 # (C) Copyright IBM Corp. 2021
 # ALL RIGHTS RESERVED
 """ A utility class to apply standardization to the data """
-from __future__ import annotations
 
 from pathlib import Path
 from typing import List, Optional
@@ -74,7 +73,7 @@ class Standardizer:
                 transformation=self.standardize_small,
             )
 
-    def standardize_one(self, rxn_smiles: str) -> StandardizationOutput:
+    def standardize_one(self, rxn_smiles: str) -> "StandardizationOutput":
         original_rxn_smiles = rxn_smiles
 
         # Remove stereo information from products, if needed

--- a/src/rxn/reaction_preprocessing/standardizer.py
+++ b/src/rxn/reaction_preprocessing/standardizer.py
@@ -58,7 +58,7 @@ class Standardizer:
 
     def standardize(self, input_csv: Path, output_csv: Path) -> None:
         editor = self._instantiate_csv_editor()
-        editor.process(input_csv, output_csv)
+        editor.process_paths(input_csv, output_csv)
 
     def _instantiate_csv_editor(self) -> StreamingCsvEditor:
         if self.keep_intermediate_columns:

--- a/src/rxn/reaction_preprocessing/standardizer.py
+++ b/src/rxn/reaction_preprocessing/standardizer.py
@@ -11,7 +11,7 @@ from typing import List, Optional
 from attr import define
 from rxn.chemutils.miscellaneous import remove_chiral_centers
 from rxn.chemutils.reaction_smiles import parse_any_reaction_smiles
-from rxn.utilities.streaming_csv_editor import StreamingCsvEditor
+from rxn.utilities.csv import StreamingCsvEditor
 
 from rxn.reaction_preprocessing.annotations.molecule_annotation import (
     MoleculeAnnotation,

--- a/src/rxn/reaction_preprocessing/standardizer.py
+++ b/src/rxn/reaction_preprocessing/standardizer.py
@@ -11,7 +11,7 @@ from typing import List, Optional
 from attr import define
 from rxn.chemutils.miscellaneous import remove_chiral_centers
 from rxn.chemutils.reaction_smiles import parse_any_reaction_smiles
-from rxn.utilities.light_csv_editor import LightCsvEditor
+from rxn.utilities.streaming_csv_editor import StreamingCsvEditor
 
 from rxn.reaction_preprocessing.annotations.molecule_annotation import (
     MoleculeAnnotation,
@@ -60,15 +60,15 @@ class Standardizer:
         editor = self._instantiate_csv_editor()
         editor.process(input_csv, output_csv)
 
-    def _instantiate_csv_editor(self) -> LightCsvEditor:
+    def _instantiate_csv_editor(self) -> StreamingCsvEditor:
         if self.keep_intermediate_columns:
-            return LightCsvEditor(
+            return StreamingCsvEditor(
                 columns_in=[self.rxn_column],
                 columns_out=StandardizationOutput.keys(self.rxn_column),
                 transformation=self.standardize_big,
             )
         else:
-            return LightCsvEditor(
+            return StreamingCsvEditor(
                 columns_in=[self.rxn_column],
                 columns_out=[self.rxn_column],
                 transformation=self.standardize_small,

--- a/tests/test_importer.py
+++ b/tests/test_importer.py
@@ -11,7 +11,7 @@ from rxn.reaction_preprocessing.config import (
     InitialDataFormat,
     RxnImportConfig,
 )
-from rxn.reaction_preprocessing.importer import InvalidColumn, InvalidType, rxn_import
+from rxn.reaction_preprocessing.importer import InvalidColumn, rxn_import
 from rxn.reaction_preprocessing.special_tokens import HEAT_TOKEN, LIGHT_TOKEN
 
 
@@ -230,8 +230,8 @@ def test_raises_when_column_name_is_incorrect(
 
 def test_light_and_heat(input_file: str, output_file: str) -> None:
     reactions = ["CC>>CC", "OO>>OO", "C.C.O>>CCO", "C=C>>CC"]
-    has_light = [False, True, True, False]
-    has_heat = [False, True, False, True]
+    has_light = [False, True, "yes", "no"]
+    has_heat = [False, True, "no", "yes"]
     # Add light token to second and third reactions, heat token to second and fourth
     expected = [
         "CC>>CC",
@@ -283,30 +283,6 @@ def test_light_and_heat_with_inexisting_column(
     )
 
     with pytest.raises(InvalidColumn):
-        rxn_import(cfg)
-
-
-def test_light_and_heat_with_non_boolean_type(
-    input_file: str, output_file: str
-) -> None:
-    reactions = ["CC>>CC", "OO>>OO", "C.C.O>>CCO", "C=C>>CC"]
-    has_light = ["no", "yes", "no", "yes"]  # Not valid - must be boolean
-    pd.DataFrame({"smiles": reactions, "light": has_light}).to_csv(
-        input_file, index=False
-    )
-
-    # Note that the input column name does not exist in the created CSV
-    cfg = RxnImportConfig(
-        input_file=input_file,
-        output_csv=output_file,
-        data_format=InitialDataFormat.CSV,
-        input_csv_column_name="smiles",
-        reaction_column_name="rxn",
-        fragment_bond=FragmentBond.TILDE,
-        column_for_light="light",
-    )
-
-    with pytest.raises(InvalidType):
         rxn_import(cfg)
 
 

--- a/tests/test_preprocessor.py
+++ b/tests/test_preprocessor.py
@@ -27,8 +27,8 @@ def test_preprocessor(tmp_dir: Path) -> None:
     dump_list_to_file(
         [
             "rxn,class",
-            "C.O.O>C>CO",
-            "C~N.N>>CNN",
+            "C.O.O>C>CO,11",
+            "C~N.N>>CNN,0",
             "[14C]Cl.O[Na]>O>[Na]Cl.[14C]O,2",
             "[14C]Cl.O[Na]>>[Na]Cl,2",
             "[C].C.[O--].[O--].O.O=[N+]([O-])c1cc(-c2nc3ccccc3o2)ccc1F.C.C>O>O.C,6",
@@ -63,8 +63,8 @@ def test_preprocessor(tmp_dir: Path) -> None:
 
     assert load_list_from_file(output_path) == [
         "rxn,class",
-        "C.O>>CO",  # removed the duplicated O and C
-        "C~N.N>>CNN",  # kept it as such
+        "C.O>>CO,11",  # removed the duplicated O and C
+        "C~N.N>>CNN,0",  # kept it as such
         "O[Na].[14C]Cl>>[Na]Cl,2",  # sorted the compounds
         "C123C45C16C21C34C561.c1ccccc1>>CC,1",
     ]

--- a/tests/test_preprocessor.py
+++ b/tests/test_preprocessor.py
@@ -2,31 +2,46 @@
 # IBM Research Zurich Licensed Internal Code
 # (C) Copyright IBM Corp. 2022
 # ALL RIGHTS RESERVED
-import pandas as pd
+from pathlib import Path
+from typing import Generator
+
 import pytest
+from rxn.utilities.files import (
+    dump_list_to_file,
+    load_list_from_file,
+    named_temporary_directory,
+)
 
 from rxn.reaction_preprocessing import MixedReactionFilter, Preprocessor
 
 
 @pytest.fixture
-def preprocessor() -> Preprocessor:
-    df = pd.DataFrame(
-        {
-            "rxn": [
-                "[14C]Cl.O[Na]>O>[Na]Cl.[14C]O",
-                "[14C]Cl.O[Na]>>[Na]Cl",
-                "[C].C.[O--].[O--].O.O=[N+]([O-])c1cc(-c2nc3ccccc3o2)ccc1F.C.C>O>O.C",
-                "=)(/?",
-            ],
-            "class": [2, 2, 6, 0],
-        }
+def tmp_dir() -> Generator[Path, None, None]:
+    with named_temporary_directory() as dir_path:
+        yield dir_path
+
+
+def test_preprocessor(tmp_dir: Path) -> None:
+    # Create fake input file
+    input_path = tmp_dir / "input.csv"
+    dump_list_to_file(
+        [
+            "rxn,class",
+            "C.O.O>C>CO",
+            "C~N.N>>CNN",
+            "[14C]Cl.O[Na]>O>[Na]Cl.[14C]O,2",
+            "[14C]Cl.O[Na]>>[Na]Cl,2",
+            "[C].C.[O--].[O--].O.O=[N+]([O-])c1cc(-c2nc3ccccc3o2)ccc1F.C.C>O>O.C,6",
+            # In an earlier version, preprocessing failed for rare cases when RDKit cannot
+            # convert concatenated SMILES into an RDKit Mol, as for the SMILES below.
+            # Was related to https://github.com/rdkit/rdkit/issues/4266
+            "c1ccccc1.C123C45C16C21C34C561>>CC,1",
+            "=)(/?,0",
+        ],
+        input_path,
     )
-    return Preprocessor(df, "rxn")
 
-
-@pytest.fixture
-def filter() -> MixedReactionFilter:
-    return MixedReactionFilter(
+    mrf = MixedReactionFilter(
         max_reactants=5,
         max_agents=0,
         max_products=1,
@@ -39,31 +54,17 @@ def filter() -> MixedReactionFilter:
         max_absolute_formal_charge=2,
     )
 
+    preprocessor = Preprocessor(
+        mixed_reaction_filter=mrf, reaction_column_name="rxn", fragment_bond="~"
+    )
 
-def test_filter(preprocessor: Preprocessor, filter: MixedReactionFilter) -> None:
-    preprocessor.filter(filter, False)
-    assert not preprocessor.df._rxn_valid.iloc[0]
-    assert preprocessor.df._rxn_valid.iloc[1]
-    assert not preprocessor.df._rxn_valid.iloc[2]
+    output_path = tmp_dir / "output.csv"
+    preprocessor.process(input_path, output_path)
 
-
-def test_filter_verbose(
-    preprocessor: Preprocessor, filter: MixedReactionFilter
-) -> None:
-    preprocessor.filter(filter, True)
-    assert len(preprocessor.df._rxn_valid_messages.iloc[0]) == 3
-    assert len(preprocessor.df._rxn_valid_messages.iloc[1]) == 0
-    assert len(preprocessor.df._rxn_valid_messages.iloc[2]) == 7
-
-
-def test_preprocess_with_rdkit_bug_for_concatenated_smiles() -> None:
-    # In an earlier version, preprocessing failed for rare cases when RDKit cannot
-    # convert concatenated SMILES into an RDKit Mol.
-    # Was related to https://github.com/rdkit/rdkit/issues/4266
-
-    df = pd.DataFrame({"rxn": ["c1ccccc1.C123C45C16C21C34C561>>CC"]})
-    preprocessor = Preprocessor(df, "rxn")
-    mrf = MixedReactionFilter()
-
-    # This used to raise an exception
-    preprocessor.filter(mrf)
+    assert load_list_from_file(output_path) == [
+        "rxn,class",
+        "C.O>>CO",  # removed the duplicated O and C
+        "C~N.N>>CNN",  # kept it as such
+        "O[Na].[14C]Cl>>[Na]Cl,2",  # sorted the compounds
+        "C123C45C16C21C34C561.c1ccccc1>>CC,1",
+    ]

--- a/tests/test_stable_data_splitter.py
+++ b/tests/test_stable_data_splitter.py
@@ -24,11 +24,6 @@ def random_strings(n: int) -> List[str]:
     ]
 
 
-@pytest.fixture
-def data() -> pd.DataFrame:
-    return pd.DataFrame(data={"col_1": random_strings(1000)})
-
-
 class SplitsDirectory:
     """Class to return as a fixture, determines paths to use in the tests, and
     populates the "input" data file."""

--- a/tests/test_stable_data_splitter.py
+++ b/tests/test_stable_data_splitter.py
@@ -3,11 +3,14 @@
 # (C) Copyright IBM Corp. 2022
 # ALL RIGHTS RESERVED
 import random
+from pathlib import Path
 from string import ascii_lowercase
-from typing import List, Sequence
+from typing import Generator, List, Tuple
 
 import pandas as pd
 import pytest
+from rxn.utilities.csv import iterate_csv_column
+from rxn.utilities.files import named_temporary_directory
 
 from rxn.reaction_preprocessing import StableDataSplitter
 from rxn.reaction_preprocessing.utils import reset_random_seed
@@ -26,14 +29,65 @@ def data() -> pd.DataFrame:
     return pd.DataFrame(data={"col_1": random_strings(1000)})
 
 
-def test_split(data: pd.DataFrame) -> None:
-    train, validate, test = StableDataSplitter.split(
-        data, "rxn", "col_1", split_ratio=0.05
-    )
+class SplitsDirectory:
+    """Class to return as a fixture, determines paths to use in the tests, and
+    populates the "input" data file."""
+
+    def __init__(self, tmp_directory: Path, content: List[str]):
+        self.directory = tmp_directory
+        self.input_csv = self.directory / "input.csv"
+        self.train_csv = self.directory / "train.csv"
+        self.valid_csv = self.directory / "validation.csv"
+        self.test_csv = self.directory / "test.csv"
+
+        # Write random data to the input
+        input_df = pd.DataFrame(
+            data={"col_1": content, "idx": list(range(len(content)))}
+        )
+        input_df.to_csv(self.input_csv, index=False)
+
+    def train_content(self, column: str) -> List[str]:
+        return list(iterate_csv_column(self.train_csv, column))
+
+    def valid_content(self, column: str) -> List[str]:
+        return list(iterate_csv_column(self.valid_csv, column))
+
+    def test_content(self, column: str) -> List[str]:
+        return list(iterate_csv_column(self.test_csv, column))
+
+    def contents(self, column: str) -> Tuple[List[str], List[str], List[str]]:
+        return (
+            self.train_content(column),
+            self.valid_content(column),
+            self.test_content(column),
+        )
+
+    def contents_as_ints(self, column: str) -> Tuple[List[int], List[int], List[int]]:
+        return (
+            [int(v) for v in self.train_content(column)],
+            [int(v) for v in self.valid_content(column)],
+            [int(v) for v in self.test_content(column)],
+        )
+
+
+@pytest.fixture
+def data_directory() -> Generator[SplitsDirectory, None, None]:
+    with named_temporary_directory() as path:
+        yield SplitsDirectory(path, content=random_strings(1000))
+
+
+def test_split(data_directory: SplitsDirectory) -> None:
+    # for conciseness
+    d = data_directory
+
+    splitter = StableDataSplitter("rxn", "col_1", split_ratio=0.05)
+    splitter.split_file(d.input_csv, d.train_csv, d.valid_csv, d.test_csv)
+
+    train, valid, test = d.contents("col_1")
     assert len(train) == 889
-    assert len(validate) == 48
+    assert len(valid) == 48
     assert len(test) == 63
-    assert validate.index.tolist() == [
+    assert [int(v) for v in d.valid_content("idx")] == [
         18,
         24,
         54,
@@ -85,108 +139,118 @@ def test_split(data: pd.DataFrame) -> None:
     ]
 
 
-def test_split_with_different_hash_seed(data: pd.DataFrame) -> None:
-    train1, validate1, test1 = StableDataSplitter.split(data, "rxn", "col_1")
-    train2, validate2, test2 = StableDataSplitter.split(
-        data, "rxn", "col_1", hash_seed=123
-    )
+def test_split_with_different_hash_seed(data_directory: SplitsDirectory) -> None:
+    # for conciseness
+    d = data_directory
+
+    # First: use default value for the hash seed
+    splitter = StableDataSplitter("rxn", "col_1")
+    splitter.split_file(d.input_csv, d.train_csv, d.valid_csv, d.test_csv)
+    train1, valid1, test1 = d.contents("col_1")
+
+    # Second: Change the hash seed
+    splitter.hash_seed = 123
+    splitter.split_file(d.input_csv, d.train_csv, d.valid_csv, d.test_csv)
+    train2, valid2, test2 = d.contents("col_1")
 
     # The generated splits must be different if the seed was different
-    assert not train2.equals(train1)
-    assert not validate2.equals(validate1)
-    assert not test2.equals(test1)
+    assert train1 != train2
+    assert valid1 != valid2
+    assert test1 != test2
 
     # Check that the size of the splits is in the accepted
     assert len(train2) == 899
-    assert len(validate2) == 58
+    assert len(valid2) == 58
     assert len(test2) == 43
 
 
-def all_samples_in_one_split(splits: Sequence[pd.DataFrame]) -> bool:
-    assert len(splits) == 3
+def all_samples_in_one_split(test_directory: SplitsDirectory, column: str) -> bool:
     number_non_empty_splits = 0
-    for split in splits:
+    for split in test_directory.contents(column):
         if len(split) != 0:
             number_non_empty_splits += 1
     return number_non_empty_splits == 1
 
 
 def test_split_on_products() -> None:
-    # With products splitting, all the reactions end up in the same split
-    df = pd.DataFrame(
-        data={"col_1": ["C>>CCC", "CC>>CCC", "CCC>>CCC", "CCCC>>CCC", "CCCCC>>CCC"]}
-    )
-    splits = StableDataSplitter.split(
-        df, reaction_column_name="col_1", index_column="products"
-    )
-    assert all_samples_in_one_split(splits)
+    splitter = StableDataSplitter(reaction_column_name="col_1", index_column="tbd")
 
-    # With normal splitting, does not all end up in the same split
-    splits = StableDataSplitter.split(
-        df, reaction_column_name="col_1", index_column="col_1"
-    )
-    assert not all_samples_in_one_split(splits)
+    with named_temporary_directory() as path:
+        d = SplitsDirectory(
+            path, content=["C>>CCC", "CC>>CCC", "CCC>>CCC", "CCCC>>CCC", "CCCCC>>CCC"]
+        )
 
-    # With precursors splitting, does not all end up in the same split
-    splits = StableDataSplitter.split(
-        df, reaction_column_name="col_1", index_column="precursors"
-    )
-    assert not all_samples_in_one_split(splits)
+        # With products splitting, all the reactions end up in the same split
+        splitter.index_column = "products"
+        splitter.split_file(d.input_csv, d.train_csv, d.valid_csv, d.test_csv)
+        assert all_samples_in_one_split(d, "col_1")
+
+        # With normal splitting, does not all end up in the same split
+        splitter.index_column = "col_1"
+        splitter.split_file(d.input_csv, d.train_csv, d.valid_csv, d.test_csv)
+        assert not all_samples_in_one_split(d, "col_1")
+
+        # With precursors splitting, does not all end up in the same split
+        splitter.index_column = "precursors"
+        splitter.split_file(d.input_csv, d.train_csv, d.valid_csv, d.test_csv)
+        assert not all_samples_in_one_split(d, "col_1")
 
 
 def test_split_on_reactants() -> None:
-    # With precursors splitting, all the reactions end up in the same split
-    df = pd.DataFrame(
-        data={
-            "col_1": [
+    splitter = StableDataSplitter(reaction_column_name="col_1", index_column="tbd")
+
+    with named_temporary_directory() as path:
+        d = SplitsDirectory(
+            path,
+            content=[
                 "C.C.C>>C",
                 "C.C.C>>CC",
                 "C.C.C>>CCC",
                 "C.C.C.C>>CCCC",
                 "C.C.C>>CCCCC",
-            ]
-        }
-    )
-    splits = StableDataSplitter.split(
-        df, reaction_column_name="col_1", index_column="precursors"
-    )
-    assert all_samples_in_one_split(splits)
+            ],
+        )
 
-    # With normal splitting, does not all end up in the same split
-    splits = StableDataSplitter.split(
-        df, reaction_column_name="col_1", index_column="col_1"
-    )
-    assert not all_samples_in_one_split(splits)
+        # With precursors splitting, all the reactions end up in the same split
+        splitter.index_column = "precursors"
+        splitter.split_file(d.input_csv, d.train_csv, d.valid_csv, d.test_csv)
+        assert all_samples_in_one_split(d, "col_1")
 
-    # With products splitting, does not all end up in the same split
-    splits = StableDataSplitter.split(
-        df, reaction_column_name="col_1", index_column="products"
-    )
-    assert not all_samples_in_one_split(splits)
+        # With normal splitting, does not all end up in the same split
+        splitter.index_column = "col_1"
+        splitter.split_file(d.input_csv, d.train_csv, d.valid_csv, d.test_csv)
+        assert not all_samples_in_one_split(d, "col_1")
+
+        # With products splitting, does not all end up in the same split
+        splitter.index_column = "products"
+        splitter.split_file(d.input_csv, d.train_csv, d.valid_csv, d.test_csv)
+        assert not all_samples_in_one_split(d, "col_1")
 
 
-def test_train_split_is_shuffled() -> None:
-    df = pd.DataFrame(data={"col_1": random_strings(1000)})
+def test_train_split_is_shuffled(data_directory: SplitsDirectory) -> None:
+    # for conciseness
+    d = data_directory
 
-    train, validate, test = StableDataSplitter.split(
-        df, "rxn", "col_1", shuffle_seed=123
-    )
+    splitter = StableDataSplitter("rxn", "col_1", shuffle_seed=123)
+    splitter.split_file(d.input_csv, d.train_csv, d.valid_csv, d.test_csv)
+
+    train, valid, test = d.contents_as_ints("idx")
 
     # The train indices should not be sorted, while the validation and test
     # indices are sorted (i.e. for validation and test, the order is the same as
     # in the original data).
-    train_indices = train.index.tolist()
-    validation_indices = validate.index.tolist()
-    test_indices = test.index.tolist()
-    assert sorted(train_indices) != train_indices
-    assert sorted(validation_indices) == validation_indices
-    assert sorted(test_indices) == test_indices
+    assert sorted(train) != train
+    assert sorted(valid) == valid
+    assert sorted(test) == test
 
     # repeating with the same seed leads to the same order
-    train_2, _, _ = StableDataSplitter.split(df, "rxn", "col_1", shuffle_seed=123)
-    assert train_2.equals(train)
+    splitter.split_file(d.input_csv, d.train_csv, d.valid_csv, d.test_csv)
+    train_2, _, _ = d.contents_as_ints("idx")
+    assert train_2 == train
 
     # repeating with a different seed leads to a different order, but the same content
-    train_3, _, _ = StableDataSplitter.split(df, "rxn", "col_1", shuffle_seed=234)
-    assert not train_3.equals(train)
-    assert sorted(train_3.index.tolist()) == sorted(train.index.tolist())
+    splitter.shuffle_seed = 234
+    splitter.split_file(d.input_csv, d.train_csv, d.valid_csv, d.test_csv)
+    train_3, _, _ = d.contents_as_ints("idx")
+    assert train_3 != train
+    assert sorted(train_3) == sorted(train)

--- a/tests/test_standardizer.py
+++ b/tests/test_standardizer.py
@@ -4,9 +4,6 @@
 # ALL RIGHTS RESERVED
 from pathlib import Path
 
-import pandas as pd
-import pytest
-
 from rxn.reaction_preprocessing import Standardizer
 from rxn.reaction_preprocessing.annotations.molecule_annotation import load_annotations
 
@@ -15,50 +12,20 @@ annotations_file = str(
 )
 
 
-@pytest.fixture
-def standardizer() -> Standardizer:
-    df = pd.DataFrame(
-        {
-            "rxn": [
-                "O=C1CCC2(CC1)OCCO2>>O=C1CCC2(C[C@H]1C)OCCO2",  # stereo only in product
-                "O=C1CCC2(CC1)OCCO2>>O=C1CCC2(C[C@@H]1C)OCCO2",  # stereo only in product
-                "[Na]Cl.CC[Zn]CC~Cc1ccccc1>>[Na]Cl",  # substitution needed
-                "[Na]Cl.Cc1ccccc1~CC[Zn]CC>>[Na]Cl",  # substitution needed but performed only if canonicalization
-                "CC.CCC>>CCO",  # no substitution
-                "CC.[NaK].CC>>[Na+]~[OH-]",  # invalid smiles -> '>>'
-                "CC(C)(C)O[K].CCO~CCO>>[Li]O",  # rejected reaction -> '>>'
-                r"CC(=O)/C=C(\C)O[V](=O)O/C(C)=C/C(C)=O.CCCC[N+](CCCC)(CCCC)CCCC~CCCC[N+](CCCC)(CCCC)CCCC~C1(=C(SC(=S)S1)[S-])[S-]~C1(=C(SC(=S)S1)[S-])[S-]~[Pd+2]>>O[K]",
-                # requires annotation -> '>>'
-            ],
-        }
-    )
+def test_standardization() -> None:
     annotations = load_annotations(annotations_file)
-    return Standardizer(df, annotations, True, "rxn", fragment_bond="~")
-
-
-@pytest.fixture
-def standardizer_without_fragment() -> Standardizer:
-    df = pd.DataFrame(
-        {
-            "rxn": [
-                "O=C1CCC2(CC1)OCCO2>>O=C1CCC2(C[C@H]1C)OCCO2",  # stereo only in product
-                "[Na]Cl.CC[Zn]CC.Cc1ccccc1>>[Na]Cl",  # requires annotation -> '>>'
-                "[Na]Cl.Cc1ccccc1.CC[Zn]CC>>[Na]Cl",  # requires annotation -> '>>'
-                "CC.CCC>>CCO",  # no substitution
-                "CC[Na5+].CC>>[Na+].[OH-]",  # invalid smiles -> '>>'
-                "CC(C)(C)O[K].CCO.CCO>>[Li]O",  # not rejected
-                r"CC(=O)/C=C(\C)O[V](=O)O/C(C)=C/C(C)=O.CCCC[N+](CCCC)(CCCC)CCCC.CCCC[N+](CCCC)(CCCC)CCCC.C1(=C(SC(=S)S1)[S-])[S-].C1(=C(SC(=S)S1)[S-])[S-].[Pd+2]>>O[K]",
-                # requires annotation -> '>>'
-            ],
-        }
-    )
-    annotations = load_annotations(annotations_file)
-    return Standardizer(df, annotations, True, "rxn", fragment_bond=None)
-
-
-def test_standardization(standardizer: Standardizer) -> None:
-    new_df = standardizer.standardize().df
-    converted_rxns = [
+    standardizer = Standardizer(annotations, True, "rxn", fragment_bond="~")
+    input_reactions = [
+        "O=C1CCC2(CC1)OCCO2>>O=C1CCC2(C[C@H]1C)OCCO2",  # stereo only in product
+        "O=C1CCC2(CC1)OCCO2>>O=C1CCC2(C[C@@H]1C)OCCO2",  # stereo only in product
+        "[Na]Cl.CC[Zn]CC~Cc1ccccc1>>[Na]Cl",  # substitution needed
+        "[Na]Cl.Cc1ccccc1~CC[Zn]CC>>[Na]Cl",  # substitution needed but performed only if canonicalization
+        "CC.CCC>>CCO",
+        "CC.[NaK].CC>>[Na+]~[OH-]",
+        "CC(C)(C)O[K].CCO~CCO>>[Li]O",
+        r"CC(=O)/C=C(\C)O[V](=O)O/C(C)=C/C(C)=O.CCCC[N+](CCCC)(CCCC)CCCC~CCCC[N+](CCCC)(CCCC)CCCC~C1(=C(SC(=S)S1)[S-])[S-]~C1(=C(SC(=S)S1)[S-])[S-]~[Pd+2]>>O[K]",
+    ]
+    expected_rxns = [
         "O=C1CCC2(CC1)OCCO2>>C[C@@H]1CC2(CCC1=O)OCCO2",
         "O=C1CCC2(CC1)OCCO2>>C[C@H]1CC2(CCC1=O)OCCO2",
         "[Na]Cl.CC[Zn]CC.Cc1ccccc1>>[Na]Cl",
@@ -69,69 +36,55 @@ def test_standardization(standardizer: Standardizer) -> None:
         ">>",  # annotation needed
     ]
 
-    assert all(
-        [
-            new_df["rxn"].values[i] == converted_rxns[i]
-            for i in range(len(converted_rxns))
-        ]
-    )
+    output_reactions = [standardizer.standardize_small(s) for s in input_reactions]
+    assert output_reactions == expected_rxns
 
 
-def test_standardization_non_canonical(standardizer: Standardizer) -> None:
-    new_df = standardizer.standardize(canonicalize=False).df
-    converted_rxns = [
-        "O=C1CCC2(CC1)OCCO2>>O=C1CCC2(C[C@H]1C)OCCO2",
-        "O=C1CCC2(CC1)OCCO2>>O=C1CCC2(C[C@@H]1C)OCCO2",
-        "[Na]Cl.CC[Zn]CC.Cc1ccccc1>>[Na]Cl",
-        ">>",  # does not reorder fragments, so it will need annotation
-        "CC.CCC>>CCO",
-        ">>",  # invalid smiles
-        ">>",  # rejected reaction
-        ">>",  # annotation needed
+def test_standardization_without_fragment() -> None:
+    annotations = load_annotations(annotations_file)
+    standardizer = Standardizer(annotations, True, "rxn", fragment_bond=None)
+    input_reactions = [
+        "O=C1CCC2(CC1)OCCO2>>O=C1CCC2(C[C@H]1C)OCCO2",  # stereo only in product
+        "[Na]Cl.CC[Zn]CC.Cc1ccccc1>>[Na]Cl",  # requires annotation -> '>>'
+        "[Na]Cl.Cc1ccccc1.CC[Zn]CC>>[Na]Cl",  # requires annotation -> '>>'
+        "CC.CCC>>CCO",  # no substitution
+        "CC[Na5+].CC>>[Na+].[OH-]",  # invalid smiles -> '>>'
+        "CC(C)(C)O[K].CCO.CCO>>[Li]O",  # not rejected
+        r"CC(=O)/C=C(\C)O[V](=O)O/C(C)=C/C(C)=O.CCCC[N+](CCCC)(CCCC)CCCC.CCCC[N+](CCCC)(CCCC)CCCC.C1(=C(SC(=S)S1)[S-])[S-].C1(=C(SC(=S)S1)[S-])[S-].[Pd+2]>>O[K]",
     ]
 
-    assert all(
-        [
-            new_df["rxn"].values[i] == converted_rxns[i]
-            for i in range(len(converted_rxns))
-        ]
-    )
-
-
-def test_standardization_without_fragment(
-    standardizer_without_fragment: Standardizer,
-) -> None:
-    new_df = standardizer_without_fragment.standardize().df
-
-    converted_rxns = [
+    expected_rxns = [
         "O=C1CCC2(CC1)OCCO2>>C[C@@H]1CC2(CCC1=O)OCCO2",
         ">>",  # does not find 'CC[Zn]CC' alone. Needs annotation
         ">>",
         "CC.CCC>>CCO",
         ">>",  # invalid smiles
-        "CC(C)(C)O[K].CCO.CCO>>[Li]O",
-        # not rejected: the check is done at the molecule level and not at the reaction level
-        ">>",
+        "CC(C)(C)O[K].CCO.CCO>>[Li]O",  # not rejected: the check is done at the molecule level and not at the reaction level
+        ">>",  # requires annotation -> '>>'
     ]
-    assert all(
-        [
-            new_df["rxn"].values[i] == converted_rxns[i]
-            for i in range(len(converted_rxns))
-        ]
+    output_reactions = [standardizer.standardize_small(s) for s in input_reactions]
+    assert output_reactions == expected_rxns
+
+
+def test_standardization_without_discarding_unannotated() -> None:
+    standardizer = Standardizer(
+        annotations=[],
+        discard_unannotated_metals=False,
+        reaction_column_name="rxn",
+        fragment_bond=None,
     )
 
+    input_reactions = [
+        "O=C1CCC2(CC1)OCCO2>>O=C1CCC2(C[C@H]1C)OCCO2",  # stereo only in product
+        "[Na]Cl.CC[Zn]CC.Cc1ccccc1>>[Na]Cl",  # requires annotation -> '>>'
+        "[Na]Cl.Cc1ccccc1.CC[Zn]CC>>[Na]Cl",  # requires annotation -> '>>'
+        "CC.CCC>>CCO",  # no substitution
+        "CC[Na5+].CC>>[Na+].[OH-]",  # invalid smiles -> '>>'
+        "CC(C)(C)O[K].CCO.CCO>>[Li]O",  # not rejected
+        r"CC(=O)/C=C(\C)O[V](=O)O/C(C)=C/C(C)=O.CCCC[N+](CCCC)(CCCC)CCCC.CCCC[N+](CCCC)(CCCC)CCCC.C1(=C(SC(=S)S1)[S-])[S-].C1(=C(SC(=S)S1)[S-])[S-].[Pd+2]>>O[K]",
+    ]
 
-def test_standardization_without_discarding_unannotated(
-    standardizer_without_fragment: Standardizer,
-) -> None:
-    standardizer_without_fragment.molecule_standardizer.discard_unannotated_metals = (
-        False
-    )
-
-    # To compare with the previous test: here the
-    new_df = standardizer_without_fragment.standardize().df
-
-    converted_rxns = [
+    expected_rxns = [
         "O=C1CCC2(CC1)OCCO2>>C[C@@H]1CC2(CCC1=O)OCCO2",
         "[Na]Cl.CC[Zn]CC.Cc1ccccc1>>[Na]Cl",
         "[Na]Cl.Cc1ccccc1.CC[Zn]CC>>[Na]Cl",
@@ -140,20 +93,30 @@ def test_standardization_without_discarding_unannotated(
         "CC(C)(C)O[K].CCO.CCO>>[Li]O",
         r"CC(=O)/C=C(\C)O[V](=O)O/C(C)=C/C(C)=O.CCCC[N+](CCCC)(CCCC)CCCC.CCCC[N+](CCCC)(CCCC)CCCC.S=c1sc([S-])c([S-])s1.S=c1sc([S-])c([S-])s1.[Pd+2]>>O[K]",
     ]
-    assert all(
-        [
-            new_df["rxn"].values[i] == converted_rxns[i]
-            for i in range(len(converted_rxns))
-        ]
+    output_reactions = [standardizer.standardize_small(s) for s in input_reactions]
+    assert output_reactions == expected_rxns
+
+
+def test_standardization_remove_stereo_when_only_in_product() -> None:
+    annotations = load_annotations(annotations_file)
+    standardizer = Standardizer(
+        annotations=annotations,
+        discard_unannotated_metals=True,
+        reaction_column_name="rxn",
+        fragment_bond="~",
+        remove_stereo_if_not_defined_in_precursors=True,
     )
-
-
-def test_standardization_remove_stereo_when_only_in_product(
-    standardizer: Standardizer,
-) -> None:
-    standardizer.remove_stereo_if_not_defined_in_precursors = True
-    new_df = standardizer.standardize().df
-    converted_rxns = [
+    input_reactions = [
+        "O=C1CCC2(CC1)OCCO2>>O=C1CCC2(C[C@H]1C)OCCO2",  # stereo only in product
+        "O=C1CCC2(CC1)OCCO2>>O=C1CCC2(C[C@@H]1C)OCCO2",  # stereo only in product
+        "[Na]Cl.CC[Zn]CC~Cc1ccccc1>>[Na]Cl",  # substitution needed
+        "[Na]Cl.Cc1ccccc1~CC[Zn]CC>>[Na]Cl",  # substitution needed but performed only if canonicalization
+        "CC.CCC>>CCO",
+        "CC.[NaK].CC>>[Na+]~[OH-]",
+        "CC(C)(C)O[K].CCO~CCO>>[Li]O",
+        r"CC(=O)/C=C(\C)O[V](=O)O/C(C)=C/C(C)=O.CCCC[N+](CCCC)(CCCC)CCCC~CCCC[N+](CCCC)(CCCC)CCCC~C1(=C(SC(=S)S1)[S-])[S-]~C1(=C(SC(=S)S1)[S-])[S-]~[Pd+2]>>O[K]",
+    ]
+    expected_rxns = [
         "O=C1CCC2(CC1)OCCO2>>CC1CC2(CCC1=O)OCCO2",
         "O=C1CCC2(CC1)OCCO2>>CC1CC2(CCC1=O)OCCO2",
         "[Na]Cl.CC[Zn]CC.Cc1ccccc1>>[Na]Cl",
@@ -163,10 +126,5 @@ def test_standardization_remove_stereo_when_only_in_product(
         ">>",  # rejected reaction
         ">>",  # annotation needed
     ]
-
-    assert all(
-        [
-            new_df["rxn"].values[i] == converted_rxns[i]
-            for i in range(len(converted_rxns))
-        ]
-    )
+    output_reactions = [standardizer.standardize_small(s) for s in input_reactions]
+    assert output_reactions == expected_rxns


### PR DESCRIPTION
Basically, this PR is solely about making the data processing script more efficient by avoiding loading of full CSV files into memory. Instead, the processing is done line-by-line.

This required a very different approach to the processing, where it was not possible to use `pandas.apply`. Instead, the code now relies on the `CsvIterator` approach from `rxn-utilities`.

All the classes were updated except the `Augmenter`.

Testing on the Pistachio dataset, we see the timings being slightly slower after the change, but the memory requirements are much smaller! For instance, at the standardization step, the difference is more than a factor of 100: ~110 MB vs ~35GB.
Differences in detail:

Before this PR:
```
    CPU time :                                   19233.39 sec.
    Max Memory :                                 47119 MB
    Average Memory :                             22810.98 MB
    Run time :                                   19343 sec.
    Turnaround time :                            19340 sec.
```

After this PR:
```
    CPU time :                                   15231.15 sec.
    Max Memory :                                 2165 MB
    Average Memory :                             397.43 MB
    Run time :                                   15314 sec.
    Turnaround time :                            15311 sec.
```

I.e., it is ~20% faster, and consumes 1/20 of the max memory, and ~1/57 of the average memory.

The generated test and validation splits are identical before and after (same md5sum). The train split is ordered differently; this is the only difference in behavior.